### PR TITLE
Update css

### DIFF
--- a/src/main.css
+++ b/src/main.css
@@ -104,88 +104,87 @@
   --status-panel: var(--light-status-panel);
 }
 
-._160d8e55254637e5-app,
-._960e4207cea8323e-bg,
-._51fd70792ee2e563-appMount,
-.ef3116c2da186559-wrapper,
-._133bf5eea8e33a34-container, ._133bf5eea8e33a34-tabBody, ._960e4207cea8323e-bg, ._160d8e55254637e5-app, ._51fd70792ee2e563-appMount, /* BASE */
-.f75fb00fb7356cbe-chat,
-.f75fb00fb7356cbe-chatContent, /*Server Chat*/
-._99e7cad8d4c55236-scroller, .e6b7699ce8339e1c-privateChannels, ._99e7cad8d4c55236-scroller, .e6b7699ce8339e1c-privateChannels, /*DMs Sidebar*/
-._7d20cf18f8a2784c-container, ._133bf5eea8e33a34-nowPlayingColumn, ._9293f6b2fc12398a-themed, /*DMs misc*/
-.visual-refresh ._133bf5eea8e33a34-tabBody, 
-._7d20cf18f8a2784c-container,
-._133bf5eea8e33a34-container,
-._2637a2609f343032-container, ._5e434347c823b592-sidebar, .ef3116c2da186559-wrapper /*Server Sidebar*/,
-.visual-refresh .clickable_f37cb1, .visual-refresh .f37cb1984c371ee5-hasBanner .f37cb1984c371ee5-header, /*Server name*/
-:where(.visual-refresh) ._740174f3d6a2c8fe-themedBackground, /*Server Textarea*/
-.visual-refresh .f369dba7416c67f0-container, /* Forum */
-._5e434347c823b592-panels, ._37e49614b9f110a9-container, /*User Profile*/
-.visual-refresh ._5e434347c823b592-sidebar:after,
-._23746ba3de9452d8-scroller, ._551b0894962ff66f-container, .theme-light .e9ef783a74d3f83a-gradient, ._8a7fc664acf53af6-backdrop /*Discovery*/,
-.visual-refresh ._23e6b439306f125a-contentRegionScroller, .visual-refresh ._23e6b439306f125a-sidebarRegionScroller, .visual-refresh ._23e6b439306f125a-standardSidebarView, ._23e6b439306f125a-contentRegion, ._960e4207cea8323e-layer /*Settings*/, 
-._1fed1dd06c7aabf7-fieldList,
-._9293f6b2fc12398a-children:after,
-.d852db00c0588eb9-wrapper, .fc817765600a960a-wrapper /* Skeleton loading */,
-.visual-refresh ._908e20001ad67812-content /*Divider*/,
-._36d072eab2b2e737-chatGradient, ._36d072eab2b2e737-chatTypingGradientNotAtBottom, ._36d072eab2b2e737-chatTypingGradientAtBottom /* Chatbox gradient */,
-._7641b507c6cdbb10-container /* Thread member list */,
-.cb9592ad77576717-channelChatWrapper, .cb9592ad77576717-wrapper /* Voice Chat message panel */ {
+.app__160d8,
+.bg__960e4,
+.appMount__51fd7,
+.wrapper_ef3116,
+.container__133bf, .tabBody__133bf, .bg__960e4, .app__160d8, .appMount__51fd7, /* BASE */
+.chat_f75fb0,
+.chatContent_f75fb0, /*Server Chat*/
+.privateChannels_e6b769, .scroller__99e7c, .privateChannels_e6b769, /*DMs Sidebar*/
+.container__7d20c, .nowPlayingColumn__133bf, .themed__9293f, /*DMs misc*/
+.container__7d20c,
+.container__133bf,
+.container__2637a, .sidebar__5e434, .wrapper_ef3116 /*Server Sidebar*/,
+.visual-refresh .clickable_f37cb1, .visual-refresh .hasBanner_f37cb1 .header_f37cb1, /*Server name*/
+:where(.visual-refresh) .themedBackground__74017, /*Server Textarea*/
+.visual-refresh .container_f369db, /* Forum */
+.panels__5e434, .container__37e49, /*User Profile*/
+.scroller__23746, .container__551b0, .theme-light .gradient_e9ef78, .backdrop__8a7fc /*Discovery*/,
+.visual-refresh .contentRegionScroller__23e6b, .visual-refresh .sidebarRegionScroller__23e6b, .visual-refresh .standardSidebarView__23e6b, .contentRegion__23e6b, .layer__960e4 /*Settings*/, 
+.fieldList__1fed1,
+.children__9293f:after,
+.wrapper_d852db, .wrapper_fc8177 /* Skeleton loading */,
+.visual-refresh .content__908e2 /*Divider*/,
+.chatGradient__36d07, .chatTypingGradientNotAtBottom__36d07, .chatTypingGradientAtBottom__36d07 /* Chatbox gradient */,
+.container__7641b /* Thread member list */,
+.channelChatWrapper_cb9592, .wrapper_cb9592 /* Voice Chat message panel */ {
   background-color: transparent !important;
   background: transparent !important;
 }
 
+
 /*Server*/
-.visual-refresh .f75fb00fb7356cbe-channelTextArea {
+.channelTextArea_f75fb0 {
   background-color: var(--channeltextarea-background);
 }
 
 /*Buttons*/
-._201d5e8a3c09670a-lookFilled._201d5e8a3c09670a-colorBrand {
+.lookFilled__201d5 .colorBrand__201d5 {
   background-color: var(--accent);
   color: var(--accent-font);
 }
-._201d5e8a3c09670a-lookFilled._201d5e8a3c09670a-colorBrand:hover {
+.lookFilled__201d5 .colorBrand__201d5:hover {
   background-color: var(--accent-hovered);
 }
-._201d5e8a3c09670a-lookFilled._201d5e8a3c09670a-colorBrand:disabled{
+.lookFilled__201d5 .colorBrand__201d5:disabled{
   background-color: var(--accent-hovered);
 }
-._201d5e8a3c09670a-lookFilled._201d5e8a3c09670a-colorPrimary, ._201d5e8a3c09670a-lookFilled._201d5e8a3c09670a-colorPrimary:disabled {
+.lookFilled__201d5 .colorPrimary__201d5, .lookFilled__201d5 .colorPrimary__201d5:disabled {
   background-color: var(--button);
   color: var(--button-font-color);
   outline: solid var(--button-border) 1.5px;
 }
 
 /*Toggle*/
-._3f21e80f8677ec40-container._3f21e80f8677ec40-checked{
+.container__3f21e .checked__3f21e{
   background-color: var(--accent) !important;
 }
-._3f21e80f8677ec40-container._3f21e80f8677ec40-checked:hover{
+.container__3f21e .checked__3f21e:hover{
   background-color: var(--accent-hovered) !important;
 }
 
 /*Special Flyout*/
-.e8b59c4b335dd2fc-messagesPopoutWrap,
+.messagesPopoutWrap_e8b59c,
 .container__2692d,
-.fc561d3c125f6a2f-container,
-._084343c4f11eaaab-contentWrapper,
-.fed6d32841cc2da2-header,
-._0d1eff984b8fd277-wrapper,
-.a16aea1526925c2c-popout,
-.c0e32c5cffed3d9f-wrapper,
-.ac6cb02cd15b4b3b-quickswitcher,
+.container_fc561d,
+.contentWrapper__08434,
+.header_fed6d3,
+.wrapper__0d1ef,
+.popout_a16aea,
+.wrapper_c0e32c,
+.quickswitcher_ac6cb0,
 .vc-notification-root,
-.b7f4b43fe1b6e285-container, .b7f4b43fe1b6e285-reactors,
-.e7d73e5106887df1-emojiRow .emojiAliasInput_e7d73e .emojiInput_e7d73e,
+.container_b7f4b4, .reactors_b7f4b4,
+.emojiRow_e7d73e .emojiAliasInput_e7d73e .emojiInput_e7d73e,
 .main__949ab,
-._6da2d8abf659f945-streamPreview,
-.c1e9c47c23f12ca3-menu /* Context menu */ {
+.streamPreview__6da2d,
+.menu_c1e9c4 /* Context menu */ {
   background-color: var(--flyout);
 }
 
 /*Thread*/
-._01ae244280823725-container {
+.container__01ae2 {
   background-color: rgba(var(--layer1),0.05);
 }
 
@@ -193,55 +192,55 @@
 .overlayBackground_c69a7b {
   background-color: var(--dm-about);
 }
-._01ae244280823725-resizeHandle {
+.resizeHandle__01ae2 {
   width: 0px;
 }
-._0f2e83213c878a13-container { /*Server Activity Status*/
-    background-color: var(--background-primary);
-    outline: solid 1px rgba(255,255,255,0.1);
+.container__0f2e8 { /*Server Activity Status*/
+  background-color: var(--background-primary);
+  outline: solid 1px rgba(255,255,255,0.1);
 }
-.ac6cb02cd15b4b3b-scroller { /*Global search*/
+.scroller_ac6cb0 { /*Global search*/
   border-radius: 5px;
   margin-right: 0px;
 }
-.visual-refresh .f75fb00fb7356cbe-form {
+.form_f75fb0 {
   margin-top: 0;
 }
-._0f481cbbd7530492-jumpToPresentBar {
+.jumpToPresentBar__0f481 {
   padding-bottom: 0;
 }
-._5eb9b3cc7c2b1ce8-lottieIcon.e131a99484292a19-buttonIcon { /* VoiceChat Soundboard icon */
+.lottieIcon__5eb9b.buttonIcon_e131a9 { /* VoiceChat Soundboard icon */
     --__lottieIconColor: white !important;
 }
-.e131a99484292a19-container { /* VoiceChat border radius */
+.container_e131a9 { /* VoiceChat border radius */
     border-radius: 8px;
 }
-.c38106a3f0c3ca76-title, .c38106a3f0c3ca76-leading, .c38106a3f0c3ca76-trailing, .c38106a3f0c3ca76-winButtons { /* Titlebar */
+.title_c38106, .leading_c38106, .trailing_c38106, .winButtons_c38106 { /* Titlebar */
   display: var(--title-bar-icon);
 }
-._5e434347c823b592-sidebarListRounded { /* Remove sidebar backdrop-filter    WHO PUTS BACKDROP FILTER HERE?? */
+.sidebarListRounded__5e434 { /* Remove sidebar backdrop-filter    WHO PUTS BACKDROP FILTER HERE?? */
   backdrop-filter: none;
   -webkit-backdrop-filter: none;
 }
-._5e434347c823b592-panels, ._37e49614b9f110a9-container { /*User Profile*/ 
+.panels__5e434, .container__37e49 { /*User Profile*/ 
   background: var(--status-panel) !important;
 }
-.visual-refresh ._740174f3d6a2c8fe-stackedBars { /* Reply Bar */
+.stackedBars__74017 { /* Reply Bar */
   background: transparent;
 }
-.d08938d21d4682b7-container { /* Discovery header fix */
+.container_d08938 { /* Discovery header fix */
   padding-top: var(--custom-channel-header-height);
 }
-._8a7fc664acf53af6-overlay { /* Discovery header fix */
+.overlay__8a7fc { /* Discovery header fix */
   top: 0px;
 }
-.bf1984a18b3ec6f0-outer { /* Activity Card */
+.outer_bf1984 { /* Activity Card */
   background-color: var(--background-primary); 
 }
 .user-profile-sidebar { /* User Profile sidebar */
   background: var(--background-primary);
 }
-._623de82e76ad7f82-embedFull { /* Embed */
+.embedFull__623de { /* Embed */
   background: var(--background-primary);
 }
 
@@ -259,6 +258,6 @@ body{
 }
 
 /* Fix semicolon bug */
-.a3002d7de5be5280-app {
+.app_a3002d {
   color: transparent;
 }


### PR DESCRIPTION
Update CSS for recent class name changes

The class names with scheme 
`._{id}-{name}` are now replaced with `.{name}__{id:5}`
`.{id}-{name}` are now replaced with `.{name}_{random:6}`

Class names are batch refactored with this Python code. (Code is generated by Gemini)
```python
import re

input_text = """

"""

def replace_class(match):
    underscore_prefix = match.group(1)
    id_part = match.group(2)
    name_part = match.group(3)
    
    # Safety check: Ignore class names that have no underscore prefix AND no numbers
    if not underscore_prefix and not any(char.isdigit() for char in id_part):
        return match.group(0)

    # If underscore is present (._) -> use 5 chars, double underscore
    if underscore_prefix == "_":
        new_random = id_part[:5]
        return f".{name_part}__{new_random}"
    # If underscore is missing -> use 6 chars, single underscore
    else:
        new_random = id_part[:6]
        return f".{name_part}_{new_random}"

pattern = r"\.(_?)([a-zA-Z0-9]+)-([a-zA-Z0-9_-]+)"

output_text = re.sub(pattern, replace_class, input_text)
print(output_text)
```